### PR TITLE
Skip SPDX packages without Package URL

### DIFF
--- a/lib/persistence/parser/spdx_result_parser.dart
+++ b/lib/persistence/parser/spdx_result_parser.dart
@@ -127,7 +127,7 @@ class _LineParser {
 
     if (_itemId == null) {
       print(
-          'Warning: Skipping package "$_packageName" because defines no Package URL');
+          'Warning: Skipping package "$_packageName" because it defines no Package URL');
       return;
     }
 

--- a/lib/persistence/parser/spdx_result_parser.dart
+++ b/lib/persistence/parser/spdx_result_parser.dart
@@ -20,6 +20,7 @@ import 'purl.dart';
 /// Assumes "concluded license" as the (SPDX) license.
 class SpdxResultParser implements ResultParser {
   final SpdxMapper mapper;
+
   SpdxResultParser(this.mapper);
 
   @override
@@ -104,6 +105,10 @@ class _LineParser {
           _license = value;
         }
         break;
+      case 'PackageLicenseDeclared':
+        if (value != 'NOASSERTION' && _license == null) {
+          _license = value;
+        }
     }
   }
 
@@ -121,8 +126,9 @@ class _LineParser {
     if (_packageName == null) return;
 
     if (_itemId == null) {
-      throw FormatException(
-          'Missing external PACKAGE-MANAGER purl reference in package "$_packageName"');
+      print(
+          'Warning: Skipping package "$_packageName" because defines no Package URL');
+      return;
     }
 
     if (_license != null) {

--- a/test/persistence/parser/spdx_result_parser_test.dart
+++ b/test/persistence/parser/spdx_result_parser_test.dart
@@ -38,10 +38,26 @@ void main() {
           containsAll(['MIT', '"Unknown"']));
     });
 
-    test('parses package unasserted license', () async {
-      final result = await parser.parse(file);
+    group('license declaration', () {
+      test('prefers concluded license', () async {
+        final result = await parser.parse(file);
 
-      expect(result[ItemId('unasserted_license', '2.0')]!.licenses, isEmpty);
+        expect(result[ItemId('group/artifact', '1.0')]!.licenses,
+            containsAll(['MIT', '"Unknown"']));
+      });
+
+      test('parses package without asserted license', () async {
+        final result = await parser.parse(file);
+
+        expect(result[ItemId('unasserted_license', '2.0')]!.licenses, isEmpty);
+      });
+
+      test('assumes declared license', () async {
+        final result = await parser.parse(file);
+
+        expect(result[ItemId('declared_license', '3.0')]!.licenses,
+            contains('Apache-2.0'));
+      });
     });
 
     test('parses text blocks', () async {
@@ -50,11 +66,10 @@ void main() {
       expect(result[ItemId('text', '3.0')], isNotNull);
     });
 
-    test('throws for missing package url', () async {
-      expect(
-          () => parser.parse(missingRefFile),
-          throwsA(predicate<PersistenceException>(
-              (e) => e.toString().contains('purl reference'))));
+    test('skips when missing package url', () async {
+      final result = await parser.parse(missingRefFile);
+
+      expect(result.items.length, 0);
     });
   });
 }

--- a/test/resources/spdx/spdx_tag_value.spdx
+++ b/test/resources/spdx/spdx_tag_value.spdx
@@ -16,8 +16,14 @@ ExternalRef: PACKAGE-MANAGER purl pkg:maven/group/artifact@1.0
 ## Start of package without asserted license
 PackageName: License not asserted
 PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: Apache-2.0
+PackageLicenseDeclared: NOASSERTION
 ExternalRef: PACKAGE-MANAGER purl pkg:npm/unasserted_license@2.0
+
+## Start of package with only declared license
+PackageName: License only declared
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: Apache-2.0
+ExternalRef: PACKAGE-MANAGER purl pkg:npm/declared_license@3.0
 
 ## Start of package with confusing text block
 PackageName: With text block


### PR DESCRIPTION
Rationale is that packages without a Package URL do not provide a unique
package identifier, but can be part of an SPDX file to indicate the internal
structure of a package. Prints a warning while skipping.